### PR TITLE
Remove Redundant Gradle Module Overriding in Android

### DIFF
--- a/Examples/CodePushDemoApp/android/settings.gradle
+++ b/Examples/CodePushDemoApp/android/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = 'CodePushDemoApp'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
-include ':app', ':code-push-next_react-native-code-push'
-project(':code-push-next_react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/@code-push-next/react-native-code-push/android/app')
+include ':app'

--- a/Examples/CodePushDemoAppNewArch/android/settings.gradle
+++ b/Examples/CodePushDemoAppNewArch/android/settings.gradle
@@ -2,6 +2,5 @@ pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'CodePushDemoAppNewArch'
-include ':app', ':code-push-next_react-native-code-push'
-project(':code-push-next_react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/@code-push-next/react-native-code-push/android/app')
+include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -19,15 +19,7 @@ In order to integrate CodePush into your Android project, please perform the fol
 
 ### Plugin Installation and Configuration for React Native 0.60 version and above (Android)
 
-1. In your `android/settings.gradle` file, make the following additions at the end of the file:
-
-    ```gradle
-    ...
-    include ':app', ':code-push-next_react-native-code-push'
-    project(':code-push-next_react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/@code-push-next/react-native-code-push/android/app')
-    ```
-    
-2. In your `android/app/build.gradle` file, add the `codepush.gradle` file as an additional build task definition to the end of the file:
+1. In your `android/app/build.gradle` file, add the `codepush.gradle` file as an additional build task definition to the end of the file:
 
     ```gradle
     ...
@@ -35,7 +27,7 @@ In order to integrate CodePush into your Android project, please perform the fol
     ...
     ```
 
-3. Update the `MainApplication` file to use CodePush via the following changes:
+2. Update the `MainApplication` file to use CodePush via the following changes:
 
     For React Native 0.73 and above: update the `MainApplication.kt`
 
@@ -91,7 +83,7 @@ In order to integrate CodePush into your Android project, please perform the fol
     }
     ```
 
-4. Add the Deployment key to `strings.xml`:
+3. Add the Deployment key to `strings.xml`:
 
    To let the CodePush runtime know which deployment it should query for updates, open your app's `strings.xml` file and add a new string named `CodePushDeploymentKey`, whose value is the key of the deployment you want to configure this app against (like the key for the `Staging` deployment for the `FooBar` app). You can retrieve this value by running `appcenter codepush deployment list -a <ownerName>/<appName> -k` in the CodePush CLI (the `-k` flag is necessary since keys aren't displayed by default) and copying the value of the `Key` column which corresponds to the deployment you want to use (see below). Note that using the deployment's name (like Staging) will not work. The "friendly name" is intended only for authenticated management usage from the CLI, and not for public consumption within your app.
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,7 +3,8 @@ module.exports = {
         platforms: {
             android: {
                 packageInstance:
-                    "new CodePush(getResources().getString(R.string.CodePushDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"
+                    "new CodePush(getResources().getString(R.string.CodePushDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)",
+                sourceDir: './android/app',
             }
         }
     }

--- a/test/test.ts
+++ b/test/test.ts
@@ -88,12 +88,6 @@ class RNAndroid extends Platform.Android implements RNPlatform {
             "apply plugin: \"com.facebook.react\"",
             "apply plugin: \"com.facebook.react\"\napply from: \"" + gradleContent + "\"");
 
-        // Add CodePush to android/settings.gradle
-        const settingsGradle = path.join(innerprojectDirectory, "android", "settings.gradle");
-        TestUtil.replaceString(settingsGradle,
-            "include ':app'",
-            "include ':app', ':code-push-next_react-native-code-push'\nproject(':code-push-next_react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/@code-push-next/react-native-code-push/android/app')");
-
         // Disable new architecture
         if (TestConfig.testOldArch) {
             const gradleProperties = path.join(innerprojectDirectory, "android", "gradle.properties");


### PR DESCRIPTION
Current code push implementation requires manual linking to update path to code-push native module even though code push module is already linked by autolinking. Add `sourceDir` in `react-native.config.js` and remove redundant gradle module overriding. 