### PR TITLE
Add retry logic to bundle download [Android]

### DIFF
--- a/Examples/CodePushDemoAppNewArch/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Examples/CodePushDemoAppNewArch/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNetworkException.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNetworkException.java
@@ -1,0 +1,22 @@
+package com.microsoft.codepush.react;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.zip.ZipException;
+
+public class CodePushNetworkException extends IOException {
+    private final int httpStatusCode;
+
+    public CodePushNetworkException(String message, int httpStatusCode) {
+        super(message + " (HTTP " + httpStatusCode + ")");
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+}

--- a/android/app/src/main/java/com/microsoft/codepush/react/RetryHelper.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/RetryHelper.java
@@ -1,0 +1,87 @@
+package com.microsoft.codepush.react;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.zip.ZipException;
+
+public class RetryHelper {
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final long BASE_RETRY_DELAY_MS = 1000;
+
+    public interface RetryableOperation {
+        void execute() throws IOException;
+    }
+
+    public static void executeWithRetry(RetryableOperation operation) throws IOException {
+        IOException lastException = null;
+        
+        for (int attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+            try {
+                operation.execute();
+                return;
+            } catch (IOException e) {
+                lastException = e;
+                
+                boolean shouldRetry = isRetryableException(e) && attempt < MAX_RETRY_ATTEMPTS;
+                
+                if (shouldRetry) {
+                    CodePushUtils.log("Download attempt " + attempt + " failed, retrying: " + e.getMessage());
+                    
+                    try {
+                        // Exponential backoff
+                        long delay = BASE_RETRY_DELAY_MS * (1L << (attempt - 1));
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Download interrupted", ie);
+                    }
+                } else {
+                    throw lastException;
+                }
+            }
+        }
+        
+        throw lastException;
+    }
+
+    private static boolean isRetryableException(IOException e) {
+        if (e instanceof CodePushNetworkException) {
+            CodePushNetworkException ne = (CodePushNetworkException) e;
+            int statusCode = ne.getHttpStatusCode();
+            if (statusCode > 0) {
+                return statusCode >= 500 || statusCode == 408 || statusCode == 429;
+            }
+        }
+        
+        return isRetryableError(e, 0);
+    }
+    
+    private static boolean isRetryableError(Throwable e, int depth) {
+        // Prevent stack overflow in recursive calls
+        if (e == null || depth > 10) {
+            return false;
+        }
+        
+        if (e instanceof SocketTimeoutException ||
+            e instanceof ConnectException ||
+            e instanceof UnknownHostException ||
+            e instanceof SocketException ||
+            e instanceof EOFException) {
+            return true;
+        }
+        
+        return isRetryableError(e.getCause(), depth + 1);
+    }
+
+    public static void checkHttpResponse(HttpURLConnection connection) throws IOException {
+        int responseCode = connection.getResponseCode();
+        if (responseCode >= 400) {
+            throw new CodePushNetworkException("HTTP error during download", responseCode);
+        }
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:8.11.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,9 +14,6 @@ buildscript {
 }
 
 allprojects {
-    android {
-        namespace "com.microsoft.codepush.react"
-    }
     repositories {
         mavenLocal()
         mavenCentral()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Aug 24 14:51:00 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/code-push-plugin-testing-framework/script/serverUtil.js
+++ b/code-push-plugin-testing-framework/script/serverUtil.js
@@ -28,6 +28,11 @@ function setupServer(targetPlatform) {
         console.log("Response: " + JSON.stringify(exports.updateResponse));
     });
     app.get("/v0.1/public/codepush/report_status/download", function (req, res) {
+        if (exports.mockDownloadFailureCount > 0) {
+            exports.mockDownloadFailureCount--;
+            res.status(500).send("Mock download failure");
+            return;
+        }
         console.log("Application downloading the package.");
         res.download(exports.updatePackagePath);
     });
@@ -54,10 +59,13 @@ exports.setupServer = setupServer;
 function cleanupServer() {
     if (exports.server) {
         exports.server.close();
+        exports.mockDownloadFailureCount = 0;
         exports.server = undefined;
     }
 }
 exports.cleanupServer = cleanupServer;
+
+exports.mockDownloadFailureCount = 0;
 //////////////////////////////////////////////////////////////////////////////////////////
 // Classes and methods used for sending mock responses to the app.
 /**

--- a/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
+++ b/code-push-plugin-testing-framework/typings/code-push-plugin-testing-framework.d.ts
@@ -274,6 +274,8 @@ declare module 'code-push-plugin-testing-framework/script/serverUtil' {
 	export var server: any;
 	/** Response the server gives the next update check request */
 	export var updateResponse: any;
+	/** Number of times to mock a download failure */
+	export var mockDownloadFailureCount: number;
 	/** Response the server gives the next test message request */
 	export var testMessageResponse: any;
 	/** Called after the next test message request */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@code-push-next/react-native-code-push",
-  "version": "10.0.1",
+  "version": "10.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code-push-next/react-native-code-push",
-      "version": "10.0.1",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
         "code-push": "4.2.3",

--- a/test/template/scenarios/scenarioRetryTransientFailure.js
+++ b/test/template/scenarios/scenarioRetryTransientFailure.js
@@ -5,26 +5,21 @@ module.exports = {
         CodePushWrapper.checkForUpdate(testApp,
             function(remotePackage) {
                 if (remotePackage) {
-                    testApp.testMessage("Starting retry behavior test");
-                    
                     // The download URL will be set to trigger retries (unreachable host, HTTP 500, etc.)
                     // RetryHelper will log retry attempts before eventually failing
                     CodePushWrapper.download(testApp, 
                         function() {
-                            testApp.testMessage("Unexpected download success");
                         },
                         function(error) {
-                            // Expected outcome after RetryHelper exhausts all retry attempts
-                            testApp.testMessage("Download failed after retry attempts: " + error.message);
                         },
                         remotePackage
                     );
                 } else {
-                    testApp.testMessage("No update available for retry test");
+                    testApp.sendTestMessage("No update available for retry test");
                 }
             },
             function(error) {
-                testApp.testMessage("Check for update failed: " + error.message);
+                testApp.sendTestMessage("Check for update failed: " + error.message);
             }
         );
     },

--- a/test/template/scenarios/scenarioRetryTransientFailure.js
+++ b/test/template/scenarios/scenarioRetryTransientFailure.js
@@ -1,0 +1,35 @@
+var CodePushWrapper = require("../codePushWrapper.js");
+
+module.exports = {
+    startTest: function (testApp) {
+        CodePushWrapper.checkForUpdate(testApp,
+            function(remotePackage) {
+                if (remotePackage) {
+                    testApp.testMessage("Starting retry behavior test");
+                    
+                    // The download URL will be set to trigger retries (unreachable host, HTTP 500, etc.)
+                    // RetryHelper will log retry attempts before eventually failing
+                    CodePushWrapper.download(testApp, 
+                        function() {
+                            testApp.testMessage("Unexpected download success");
+                        },
+                        function(error) {
+                            // Expected outcome after RetryHelper exhausts all retry attempts
+                            testApp.testMessage("Download failed after retry attempts: " + error.message);
+                        },
+                        remotePackage
+                    );
+                } else {
+                    testApp.testMessage("No update available for retry test");
+                }
+            },
+            function(error) {
+                testApp.testMessage("Check for update failed: " + error.message);
+            }
+        );
+    },
+
+    getScenarioName: function () {
+        return "Retry Behavior Test";
+    }
+};

--- a/test/test.ts
+++ b/test/test.ts
@@ -535,6 +535,7 @@ const ScenarioSyncMandatoryDefault = "scenarioSyncMandatoryDefault.js";
 const ScenarioSyncMandatoryResume = "scenarioSyncMandatoryResume.js";
 const ScenarioSyncMandatoryRestart = "scenarioSyncMandatoryRestart.js";
 const ScenarioSyncMandatorySuspend = "scenarioSyncMandatorySuspend.js";
+const ScenarioRetryTransientFailure = "scenarioRetryTransientFailure.js";
 
 const UpdateDeviceReady = "updateDeviceReady.js";
 const UpdateNotifyApplicationReady = "updateNotifyApplicationReady.js";
@@ -1632,4 +1633,22 @@ PluginTestingFramework.initializeTests(new RNProjectManager(), supportedTargetPl
                             .done(() => { done(); }, (e) => { done(e); });
                     });
             });
+
+        TestBuilder.describe("#RetryHelper",
+            () => {
+                TestBuilder.it("retries network failures and logs retry attempts", true,
+                    (done: Mocha.Done) => {
+                        ServerUtil.updateResponse = { update_info: ServerUtil.createUpdateResponse(false, targetPlatform) };
+
+                        /* Use an unreachable host to trigger network timeouts that will be retried */
+                        ServerUtil.updateResponse.update_info.download_url = "http://unreachable-host-for-retry-test.invalid/update.zip";
+
+                        projectManager.runApplication(TestConfig.testRunDirectory, targetPlatform);
+
+                        ServerUtil.expectTestMessages([
+                            ServerUtil.TestMessage.CHECK_UPDATE_AVAILABLE,
+                            ServerUtil.TestMessage.DOWNLOAD_ERROR])
+                            .then(() => { done(); }, (e) => { done(e); });
+                    });
+            }, ScenarioRetryTransientFailure);
     });


### PR DESCRIPTION
Discussion: #27 

Initial draft with Android-only implementation without any complexities like configurable retries.

The main addition is `RetryHelper.java`, which retries a lambda (the network download in our case) when an exception is thrown and it's deemed retryable. What is retryable: a few known Java exception classes and certain HTTP status codes.

### TODO

- [ ] Proper testing: I'm looking for feedback about how to test this properly. With the current E2E test utils, it's not possible to create a scenario where a request fails for the first try but succeeds after a retry. So the tests mostly verify that this change doesn't introduce regressions, but doesn't test the new retry.
- [ ] Retry configuration: would it make sense to expose the retry config to the JS API? We should probably only do that once all 3 platforms do retries.
- [ ] `DownloadProgressCallback`: with this new retry logic, the `receivedBytes` field could jump backwards if/when a retry is performed. I'm not sure how important this is, we could introduce a new field like `int attempts` in the callback.