### PR TITLE
Fix ReactHostDelegate ProGuard rule

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -23,6 +23,7 @@
 
 -keepclassmembers class com.facebook.react.runtime.ReactHostImpl {
     private final ** mReactHostDelegate;
+    private final ** reactHostDelegate;
 }
 
 -keep interface com.facebook.react.runtime.ReactHostDelegate { *; }


### PR DESCRIPTION
Adds `reactHostDelegate` to the Android consumer ProGuard rules for `ReactHostImpl`.

When ProGuard / R8 minification is enabled, CodePush uses reflection to access `ReactHostImpl.reactHostDelegate` in the new architecture path. If that field name is obfuscated, the reflective lookup can fail and the updated JS bundle may not be applied on the first restart after an update.