### PR TITLE
Fix Expo config plugin dependency resolution

### DIFF
--- a/expo.js
+++ b/expo.js
@@ -5,7 +5,7 @@ const {
   withAppBuildGradle,
   withMainApplication, // Using the safer, higher-level helper
   WarningAggregator,
-} = require('@expo/config-plugins');
+} = require('expo/config-plugins');
 const fs = require('fs');
 const path = require('path');
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,14 @@
     "type": "git",
     "url": "https://github.com/codemagic-ci-cd/react-native-code-push"
   },
+  "peerDependencies": {
+    "expo": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "code-push": "4.2.3",
     "glob": "^7.1.7",


### PR DESCRIPTION
Following [Expo's config plugin guidance](https://docs.expo.dev/config-plugins/development-and-debugging/):
- Import from `expo/config-plugins` instead of `@expo/config-plugins`, so the loaded version always matches the app's Expo SDK.
- Declare `expo` as an optional peer dependency so isolated installers link the host project's `expo` into this package. 